### PR TITLE
Added Effect Category to Tooltip

### DIFF
--- a/Common/src/main/java/net/darkhax/effecttooltips/ConfigSchema.java
+++ b/Common/src/main/java/net/darkhax/effecttooltips/ConfigSchema.java
@@ -1,0 +1,59 @@
+package net.darkhax.effecttooltips;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ConfigSchema {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().excludeFieldsWithoutExposeAnnotation().create();
+
+    @Expose
+    public boolean showEffectCategory = true;
+
+    public static ConfigSchema load(File configFile) {
+
+        ConfigSchema config = new ConfigSchema();
+
+        // Attempt to load existing config file
+        if (configFile.exists()) {
+
+            try (FileReader reader = new FileReader(configFile)) {
+
+                config = GSON.fromJson(reader, ConfigSchema.class);
+                Constants.LOG.info("Loaded config file.");
+            }
+
+            catch (Exception e) {
+
+                Constants.LOG.error("Could not read config file {}. Defaults will be used.", configFile.getAbsolutePath());
+                Constants.LOG.catching(e);
+            }
+        }
+
+        else {
+
+            Constants.LOG.info("Creating a new config file at {}.", configFile.getAbsolutePath());
+            configFile.getParentFile().mkdirs();
+        }
+
+        try (FileWriter writer = new FileWriter(configFile)) {
+
+            GSON.toJson(config, writer);
+            Constants.LOG.info("Saved config file.");
+        }
+
+        catch (Exception e) {
+
+            Constants.LOG.error("Could not write config file '{}'!", configFile.getAbsolutePath());
+            Constants.LOG.catching(e);
+        }
+
+        return config;
+    }
+}

--- a/Common/src/main/java/net/darkhax/effecttooltips/Constants.java
+++ b/Common/src/main/java/net/darkhax/effecttooltips/Constants.java
@@ -1,0 +1,11 @@
+package net.darkhax.effecttooltips;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Constants {
+
+    public static final String MOD_ID = "effecttooltips";
+    public static final String MOD_NAME = "EffectTooltips";
+    public static final Logger LOG = LogManager.getLogger(MOD_NAME);
+}

--- a/Common/src/main/java/net/darkhax/effecttooltips/EffectTooltipsCommon.java
+++ b/Common/src/main/java/net/darkhax/effecttooltips/EffectTooltipsCommon.java
@@ -1,0 +1,12 @@
+package net.darkhax.effecttooltips;
+
+import java.nio.file.Path;
+
+public class EffectTooltipsCommon {
+
+    public static ConfigSchema config;
+
+    public EffectTooltipsCommon(Path configPath) {
+        this.config = ConfigSchema.load(configPath.resolve(Constants.MOD_ID + ".json").toFile());
+    }
+}

--- a/Fabric/src/main/java/net/darkhax/effecttooltips/EffectTooltipsFabric.java
+++ b/Fabric/src/main/java/net/darkhax/effecttooltips/EffectTooltipsFabric.java
@@ -37,6 +37,7 @@ public class EffectTooltipsFabric implements ModInitializer {
 
     @Override
     public void onInitialize() {
+        new EffectTooltipsCommon(FabricLoader.getInstance().getConfigDir());
 
         EffectTooltips.init((modId) -> Component.translatable(FabricLoader.getInstance().getModContainer(modId).map(mod -> mod.getMetadata().getName()).orElse(modId)));
     }

--- a/Fabric/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
+++ b/Fabric/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
@@ -1,6 +1,7 @@
 package net.darkhax.effecttooltips.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.darkhax.effecttooltips.EffectTooltipsCommon;
 import net.darkhax.effecttooltips.api.event.EffectTooltips;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -94,13 +95,17 @@ public abstract class MixinEffectScreen extends AbstractContainerScreen {
 
             // Build the broader tooltip by posting events for each hovered effect individually.
             for (MobEffectInstance effect : this.hoveredEffects) {
-                MobEffectCategory effectCategory = effect.getEffect().getCategory();
-
                 final List<Component> effectTooltip = new LinkedList<>();
 
                 // Vanilla tooltip content parity.
                 effectTooltip.add(this.getEffectName(effect));
-                effectTooltip.add(Component.translatable(StringUtils.capitalize(effectCategory.name().toLowerCase())).withStyle(effectCategory.getTooltipFormatting()));
+
+                // Show effect category in tooltip if enabled in config
+                if (EffectTooltipsCommon.config.showEffectCategory) {
+                    MobEffectCategory effectCategory = effect.getEffect().getCategory();
+                    effectTooltip.add(Component.translatable(StringUtils.capitalize(effectCategory.name().toLowerCase())).withStyle(effectCategory.getTooltipFormatting()));
+                }
+
                 effectTooltip.add(Component.translatable(MobEffectUtil.formatDuration(effect, 1.0F)));
 
                 // Post individual effect tooltip.

--- a/Fabric/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
+++ b/Fabric/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
@@ -6,11 +6,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffectUtil;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.TooltipFlag;
+import org.apache.commons.lang3.StringUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -92,12 +94,14 @@ public abstract class MixinEffectScreen extends AbstractContainerScreen {
 
             // Build the broader tooltip by posting events for each hovered effect individually.
             for (MobEffectInstance effect : this.hoveredEffects) {
+                MobEffectCategory effectCategory = effect.getEffect().getCategory();
 
                 final List<Component> effectTooltip = new LinkedList<>();
 
                 // Vanilla tooltip content parity.
                 effectTooltip.add(this.getEffectName(effect));
-                effectTooltip.add(Component.literal(MobEffectUtil.formatDuration(effect, 1.0F)));
+                effectTooltip.add(Component.translatable(StringUtils.capitalize(effectCategory.name().toLowerCase())).withStyle(effectCategory.getTooltipFormatting()));
+                effectTooltip.add(Component.translatable(MobEffectUtil.formatDuration(effect, 1.0F)));
 
                 // Post individual effect tooltip.
                 EffectTooltips.EVENTS.postEffectTooltip(effect, effectTooltip, this.compactEffectRendering, flag);

--- a/Forge/src/main/java/net/darkhax/effecttooltips/EffectTooltipsForge.java
+++ b/Forge/src/main/java/net/darkhax/effecttooltips/EffectTooltipsForge.java
@@ -4,11 +4,13 @@ import net.darkhax.effecttooltips.api.event.EffectTooltips;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.loading.FMLPaths;
 
 @Mod(EffectTooltips.MOD_ID)
 public class EffectTooltipsForge {
 
     public EffectTooltipsForge() {
+        new EffectTooltipsCommon(FMLPaths.CONFIGDIR.get());
 
         EffectTooltips.init((modId) -> Component.translatable(ModList.get().getModContainerById(modId).map(mod -> mod.getModInfo().getDisplayName()).orElse(modId)));
     }

--- a/Forge/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
+++ b/Forge/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
@@ -1,6 +1,7 @@
 package net.darkhax.effecttooltips.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.darkhax.effecttooltips.EffectTooltipsCommon;
 import net.darkhax.effecttooltips.api.event.EffectTooltips;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -94,13 +95,17 @@ public abstract class MixinEffectScreen extends AbstractContainerScreen {
 
             // Build the broader tooltip by posting events for each hovered effect individually.
             for (MobEffectInstance effect : this.hoveredEffects) {
-                MobEffectCategory effectCategory = effect.getEffect().getCategory();
-
                 final List<Component> effectTooltip = new LinkedList<>();
 
                 // Vanilla tooltip content parity.
                 effectTooltip.add(this.getEffectName(effect));
-                effectTooltip.add(Component.translatable(StringUtils.capitalize(effectCategory.name().toLowerCase())).withStyle(effectCategory.getTooltipFormatting()));
+
+                // Show effect category in tooltip if enabled in config
+                if (EffectTooltipsCommon.config.showEffectCategory) {
+                    MobEffectCategory effectCategory = effect.getEffect().getCategory();
+                    effectTooltip.add(Component.translatable(StringUtils.capitalize(effectCategory.name().toLowerCase())).withStyle(effectCategory.getTooltipFormatting()));
+                }
+
                 effectTooltip.add(Component.translatable(MobEffectUtil.formatDuration(effect, 1.0F)));
 
                 // Post individual effect tooltip.

--- a/Forge/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
+++ b/Forge/src/main/java/net/darkhax/effecttooltips/mixin/MixinEffectScreen.java
@@ -6,11 +6,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffectUtil;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.TooltipFlag;
+import org.apache.commons.lang3.StringUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -92,11 +94,13 @@ public abstract class MixinEffectScreen extends AbstractContainerScreen {
 
             // Build the broader tooltip by posting events for each hovered effect individually.
             for (MobEffectInstance effect : this.hoveredEffects) {
+                MobEffectCategory effectCategory = effect.getEffect().getCategory();
 
                 final List<Component> effectTooltip = new LinkedList<>();
 
                 // Vanilla tooltip content parity.
                 effectTooltip.add(this.getEffectName(effect));
+                effectTooltip.add(Component.translatable(StringUtils.capitalize(effectCategory.name().toLowerCase())).withStyle(effectCategory.getTooltipFormatting()));
                 effectTooltip.add(Component.translatable(MobEffectUtil.formatDuration(effect, 1.0F)));
 
                 // Post individual effect tooltip.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=5.0
+version=5.1
 group=net.darkhax.effecttooltips
 
 # Common


### PR DESCRIPTION
Let me know if you'd like it differently. Or if not at all, no worries :)

I also changed
`effectTooltip.add(Component.literal(MobEffectUtil.formatDuration(effect, 1.0F)));`
to
`effectTooltip.add(Component.translatable(MobEffectUtil.formatDuration(effect, 1.0F)));`

for Fabric. They're the same for Forge/Fabric now.

Examples:
![](https://i.gyazo.com/713b65202637f4722a18b77d915a8086.gif)
![](https://i.gyazo.com/68f8628e3925776c8f9a31e07c62b80b.gif)